### PR TITLE
Compat shim for openpgp-0.6

### DIFF
--- a/Data/OpenPGP/Crypto.hs
+++ b/Data/OpenPGP/Crypto.hs
@@ -6,54 +6,54 @@
 -- > import qualified Data.OpenPGP.Crypto as OpenPGP
 module Data.OpenPGP.Crypto (sign, verify, fingerprint) where
 
-import Numeric
-import Data.Word
-import Data.Bits
-import Data.Char
-import Data.List (find,foldl')
-import qualified Data.ByteString.Lazy as LZ
+import           Data.Bits
+import qualified Data.ByteString.Lazy      as LZ
 import qualified Data.ByteString.Lazy.UTF8 as LZ (fromString)
+import           Data.Char
+import           Data.List                 (find, foldl')
+import           Data.Word
+import           Numeric
 
-import Data.Binary
-import Codec.Utils (fromOctets)
-import qualified Codec.Encryption.RSA as RSA
-import qualified Data.Digest.MD5 as MD5
-import qualified Data.Digest.SHA1 as SHA1
-import qualified Data.Digest.SHA256 as SHA256
-import qualified Data.Digest.SHA384 as SHA384
-import qualified Data.Digest.SHA512 as SHA512
+import qualified Codec.Encryption.RSA      as RSA
+import           Codec.Utils               (fromOctets)
+import           Data.Binary
+import qualified Data.Digest.MD5           as MD5
+import qualified Data.Digest.SHA1          as SHA1
+import qualified Data.Digest.SHA256        as SHA256
+import qualified Data.Digest.SHA384        as SHA384
+import qualified Data.Digest.SHA512        as SHA512
 
-import qualified Data.OpenPGP as OpenPGP
+import qualified Data.OpenPGP              as OpenPGP
 
 -- | Generate a key fingerprint from a PublicKeyPacket or SecretKeyPacket
 -- <http://tools.ietf.org/html/rfc4880#section-12.2>
 fingerprint :: OpenPGP.Packet -> String
 fingerprint p
-	| OpenPGP.version p == 4 =
-		map toUpper $ (`showHex` "") $ SHA1.toInteger $ SHA1.hash $
-			LZ.unpack (LZ.concat (OpenPGP.fingerprint_material p))
-	| OpenPGP.version p `elem` [2, 3] =
-		map toUpper $ foldr (pad `oo` showHex) "" $
-			MD5.hash $ LZ.unpack (LZ.concat (OpenPGP.fingerprint_material p))
-	| otherwise = error "Unsupported Packet version or type in fingerprint"
-	where
-	oo = (.) . (.)
-	pad s | odd $ length s = '0':s
-	      | otherwise = s
+        | OpenPGP.version p == 4 =
+                map toUpper $ (`showHex` "") $ SHA1.toInteger $ SHA1.hash $
+                        LZ.unpack (LZ.concat (OpenPGP.fingerprint_material p))
+        | OpenPGP.version p `elem` [2, 3] =
+                map toUpper $ foldr (pad `oo` showHex) "" $
+                        MD5.hash $ LZ.unpack (LZ.concat (OpenPGP.fingerprint_material p))
+        | otherwise = error "Unsupported Packet version or type in fingerprint"
+        where
+        oo = (.) . (.)
+        pad s | odd $ length s = '0':s
+              | otherwise = s
 
 find_key :: OpenPGP.Message -> String -> Maybe OpenPGP.Packet
 find_key = OpenPGP.find_key fingerprint
 
 keyfield_as_octets :: OpenPGP.Packet -> Char -> [Word8]
 keyfield_as_octets k f =
-	LZ.unpack $ LZ.drop 2 (encode fld)
-	where
-	Just fld = lookup f (OpenPGP.key k)
+        LZ.unpack $ LZ.drop 2 (encode fld)
+        where
+        Just fld = lookup f (OpenPGP.key k)
 
 constTimeEq :: [Word8] -> [Word8] -> Bool
 constTimeEq xs ys
-	| length xs /= length ys = False
-	| otherwise = 0 == foldl' (\r (x,y) -> r .|. (x `xor` y)) 0 (zip xs ys)
+        | length xs /= length ys = False
+        | otherwise = 0 == foldl' (\r (x,y) -> r .|. (x `xor` y)) 0 (zip xs ys)
 
 -- http://tools.ietf.org/html/rfc3447#page-43
 emsa_pkcs1_v1_5_hash_padding :: OpenPGP.HashAlgorithm -> [Word8]
@@ -63,7 +63,7 @@ emsa_pkcs1_v1_5_hash_padding OpenPGP.SHA256 = [0x30, 0x31, 0x30, 0x0d, 0x06, 0x0
 emsa_pkcs1_v1_5_hash_padding OpenPGP.SHA384 = [0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0x04, 0x30]
 emsa_pkcs1_v1_5_hash_padding OpenPGP.SHA512 = [0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40]
 emsa_pkcs1_v1_5_hash_padding _ =
-	error "Unsupported HashAlgorithm in emsa_pkcs1_v1_5_hash_padding."
+        error "Unsupported HashAlgorithm in emsa_pkcs1_v1_5_hash_padding."
 
 hash :: OpenPGP.HashAlgorithm -> [Word8] -> [Word8]
 hash OpenPGP.MD5 = MD5.hash
@@ -75,8 +75,8 @@ hash _ = error "Unsupported HashAlgorithm in hash."
 
 emsa_pkcs1_v1_5_encode :: [Word8] -> Int -> OpenPGP.HashAlgorithm -> [Word8]
 emsa_pkcs1_v1_5_encode m emLen algo =
-	[0, 1] ++ replicate (emLen - length t - 3) 0xff ++ [0] ++ t
-	where t = emsa_pkcs1_v1_5_hash_padding algo ++ hash algo m
+        [0, 1] ++ replicate (emLen - length t - 3) 0xff ++ [0] ++ t
+        where t = emsa_pkcs1_v1_5_hash_padding algo ++ hash algo m
 
 -- | Verify a message signature.  Only supports RSA keys for now.
 verify :: OpenPGP.Message    -- ^ Keys that may have made the signature
@@ -84,18 +84,18 @@ verify :: OpenPGP.Message    -- ^ Keys that may have made the signature
           -> Int             -- ^ Index of signature to verify (0th, 1st, etc)
           -> Bool
 verify keys message sigidx =
-	encoded `constTimeEq` RSA.encrypt (n, e) raw_sig
-	where
-	raw_sig = LZ.unpack $ LZ.drop 2 $ encode (head $ OpenPGP.signature sig)
-	encoded = emsa_pkcs1_v1_5_encode signature_over
-		(length n) (OpenPGP.hash_algorithm sig)
-	signature_over = LZ.unpack $ dta `LZ.append` OpenPGP.trailer sig
-	(n, e) = (keyfield_as_octets k 'n', keyfield_as_octets k 'e')
-	Just k = find_key keys issuer
-	Just issuer = OpenPGP.signature_issuer sig
-	sig = sigs !! sigidx
-	(sigs, (OpenPGP.LiteralDataPacket {OpenPGP.content = dta}):_) =
-		OpenPGP.signatures_and_data message
+        encoded `constTimeEq` RSA.encrypt (n, e) raw_sig
+        where
+        raw_sig = LZ.unpack $ LZ.drop 2 $ encode (head $ OpenPGP.signature sig)
+        encoded = emsa_pkcs1_v1_5_encode signature_over
+                (length n) (OpenPGP.hash_algorithm sig)
+        signature_over = LZ.unpack $ dta `LZ.append` OpenPGP.trailer sig
+        (n, e) = (keyfield_as_octets k 'n', keyfield_as_octets k 'e')
+        Just k = find_key keys issuer
+        Just issuer = OpenPGP.signature_issuer sig
+        sig = sigs !! sigidx
+        (sigs, (OpenPGP.LiteralDataPacket {OpenPGP.content = dta}):_) =
+                OpenPGP.signatures_and_data message
 
 -- | Sign data or key/userID pair.  Only supports RSA keys for now.
 sign :: OpenPGP.Message    -- ^ SecretKeys, one of which will be used
@@ -105,72 +105,72 @@ sign :: OpenPGP.Message    -- ^ SecretKeys, one of which will be used
         -> Integer -- ^ Timestamp for signature (unless sig supplied)
         -> OpenPGP.Packet
 sign keys message hsh keyid timestamp =
-	-- WARNING: this style of update is unsafe on most fields
-	-- it is safe on signature and hash_head, though
-	sig {
-		OpenPGP.signature = [OpenPGP.MPI $ toNum final],
-		OpenPGP.hash_head = toNum $ take 2 encoded
-	}
-	where
-	-- toNum has explicit param so that it can remain polymorphic
-	toNum l = fromOctets (256::Integer) l
-	final   = dropWhile (==0) $ RSA.decrypt (n, d) encoded
-	encoded = emsa_pkcs1_v1_5_encode dta (length n) hsh
-	(n, d)  = (keyfield_as_octets k 'n', keyfield_as_octets k 'd')
-	dta     = LZ.unpack $ case signOver of {
-		OpenPGP.LiteralDataPacket {OpenPGP.content = c} -> c;
-		_ -> LZ.concat $ OpenPGP.fingerprint_material signOver ++ [
-			LZ.singleton 0xB4,
-			encode (fromIntegral (length firstUserID) :: Word32),
-			LZ.fromString firstUserID
-		]
-	} `LZ.append` OpenPGP.trailer sig
-	sig     = findSigOrDefault (find OpenPGP.isSignaturePacket m)
+        -- WARNING: this style of update is unsafe on most fields
+        -- it is safe on signature and hash_head, though
+        sig {
+                OpenPGP.signature = [OpenPGP.MPI $ toNum final],
+                OpenPGP.hash_head = toNum $ take 2 encoded
+        }
+        where
+        -- toNum has explicit param so that it can remain polymorphic
+        toNum l = fromOctets (256::Integer) l
+        final   = dropWhile (==0) $ RSA.decrypt (n, d) encoded
+        encoded = emsa_pkcs1_v1_5_encode dta (length n) hsh
+        (n, d)  = (keyfield_as_octets k 'n', keyfield_as_octets k 'd')
+        dta     = LZ.unpack $ case signOver of {
+                OpenPGP.LiteralDataPacket {OpenPGP.content = c} -> c;
+                _ -> LZ.concat $ OpenPGP.fingerprint_material signOver ++ [
+                        LZ.singleton 0xB4,
+                        encode (fromIntegral (length firstUserID) :: Word32),
+                        LZ.fromString firstUserID
+                ]
+        } `LZ.append` OpenPGP.trailer sig
+        sig     = findSigOrDefault (find OpenPGP.isSignaturePacket m)
 
-	-- Either a SignaturePacket was found, or we need to make one
-	findSigOrDefault (Just s) = OpenPGP.signaturePacket
-		(OpenPGP.version s)
-		(OpenPGP.signature_type s)
-		OpenPGP.RSA -- force key and hash algorithm
-		hsh
-		(OpenPGP.hashed_subpackets s)
-		(OpenPGP.unhashed_subpackets s)
-		(OpenPGP.hash_head s)
-		(OpenPGP.signature s)
-	findSigOrDefault Nothing  = OpenPGP.signaturePacket
-		4
-		defaultStype
-		OpenPGP.RSA
-		hsh
-		([
-			-- Do we really need to pass in timestamp just for the default?
-			OpenPGP.SignatureCreationTimePacket $ fromIntegral timestamp,
-			OpenPGP.IssuerPacket keyid'
-		] ++ (case signOver of
-			OpenPGP.LiteralDataPacket {} -> []
-			_ -> [] -- TODO: OpenPGP.KeyFlagsPacket [0x01, 0x02]
-		))
-		[]
-		undefined
-		undefined
+        -- Either a SignaturePacket was found, or we need to make one
+        findSigOrDefault (Just s) = OpenPGP.signaturePacket
+                (OpenPGP.version s)
+                (OpenPGP.signature_type s)
+                OpenPGP.RSA -- force key and hash algorithm
+                hsh
+                (OpenPGP.hashed_subpackets s)
+                (OpenPGP.unhashed_subpackets s)
+                (OpenPGP.hash_head s)
+                (OpenPGP.signature s)
+        findSigOrDefault Nothing  = OpenPGP.signaturePacket
+                4
+                defaultStype
+                OpenPGP.RSA
+                hsh
+                ([
+                        -- Do we really need to pass in timestamp just for the default?
+                        OpenPGP.SignatureCreationTimePacket $ fromIntegral timestamp,
+                        OpenPGP.IssuerPacket keyid'
+                ] ++ (case signOver of
+                        OpenPGP.LiteralDataPacket {} -> []
+                        _                            -> [] -- TODO: OpenPGP.KeyFlagsPacket [0x01, 0x02]
+                ))
+                []
+                undefined
+                undefined
 
-	keyid'  = reverse $ take 16 $ reverse $ fingerprint k
-	Just k  = find_key keys keyid
+        keyid'  = reverse $ take 16 $ reverse $ fingerprint k
+        Just k  = find_key keys keyid
 
-	Just (OpenPGP.UserIDPacket firstUserID) = find isUserID m
+        Just (OpenPGP.UserIDPacket firstUserID) = find isUserID m
 
-	defaultStype = case signOver of
-		OpenPGP.LiteralDataPacket {OpenPGP.format = f} ->
-			if f == 'b' then 0x00 else 0x01
-		_ -> 0x13
+        defaultStype = case signOver of
+                OpenPGP.LiteralDataPacket {OpenPGP.format = f} ->
+                        if f == 'b' then 0x00 else 0x01
+                _ -> 0x13
 
-	Just signOver = find isSignable m
-	OpenPGP.Message m = message
+        Just signOver = find isSignable m
+        OpenPGP.Message m = message
 
-	isSignable (OpenPGP.LiteralDataPacket {}) = True
-	isSignable (OpenPGP.PublicKeyPacket {})   = True
-	isSignable (OpenPGP.SecretKeyPacket {})   = True
-	isSignable _                              = False
+        isSignable (OpenPGP.LiteralDataPacket {}) = True
+        isSignable (OpenPGP.PublicKeyPacket {})   = True
+        isSignable (OpenPGP.SecretKeyPacket {})   = True
+        isSignable _                              = False
 
-	isUserID (OpenPGP.UserIDPacket {})        = True
-	isUserID _                                = False
+        isUserID (OpenPGP.UserIDPacket {}) = True
+        isUserID _                         = False

--- a/Data/OpenPGP/Crypto.hs
+++ b/Data/OpenPGP/Crypto.hs
@@ -95,7 +95,17 @@ verify keys message sigidx =
         Just issuer = OpenPGP.signature_issuer sig
         sig = sigs !! sigidx
         (sigs, (OpenPGP.LiteralDataPacket {OpenPGP.content = dta}):_) =
-                OpenPGP.signatures_and_data message
+                signatures_and_data message
+
+-- | Extract all signature and data packets from a 'Message'
+signatures_and_data :: OpenPGP.Message -> ([OpenPGP.Packet], [OpenPGP.Packet])
+signatures_and_data (OpenPGP.Message ((OpenPGP.CompressedDataPacket {OpenPGP.message = m}):_)) =
+        signatures_and_data m
+signatures_and_data (OpenPGP.Message lst) =
+        (filter OpenPGP.isSignaturePacket lst, filter isDta lst)
+        where
+        isDta (OpenPGP.LiteralDataPacket {}) = True
+        isDta _                              = False
 
 -- | Sign data or key/userID pair.  Only supports RSA keys for now.
 sign :: OpenPGP.Message    -- ^ SecretKeys, one of which will be used

--- a/openpgp-Crypto.cabal
+++ b/openpgp-Crypto.cabal
@@ -1,6 +1,6 @@
 name:            openpgp-Crypto
-version:         0.5
-cabal-version:   >= 1.8
+version:         0.5.0.1
+cabal-version:   >= 1.10
 license:         OtherLicense
 license-file:    COPYING
 category:        Cryptography
@@ -39,28 +39,36 @@ extra-source-files:
         tests/data/compressedsig-bzip2.gpg
 
 library
+        default-language: Haskell2010
         exposed-modules:
                 Data.OpenPGP.Crypto
 
         build-depends:
-                base == 4.*,
-                bytestring,
-                utf8-string,
-                binary,
-                openpgp <= 0.5,
-                Crypto
+                base        == 4.*,
+                bytestring  >= 0.9 && < 0.11,
+                utf8-string >= 1 && < 1.1,
+                binary      < 0.9,
+                openpgp     == 0.6.*,
+                Crypto      >= 4.2.5.1 && < 4.3
 
 test-suite tests
+        default-language: Haskell2010
         type:       exitcode-stdio-1.0
-        main-is:    tests/suite.hs
+        main-is:    suite.hs
+        hs-source-dirs: tests
 
         build-depends:
-                base == 4.*,
+                -- internal lib dependency
+                openpgp-Crypto,
+                -- constraints inherited via lib:openpgp-Crypto component
+                base,
                 bytestring,
                 utf8-string,
                 binary,
-                openpgp <= 0.5,
-                Crypto,
+                openpgp
+
+        build-depends:
+                -- deps w/o non-inherited version constraints
                 HUnit,
                 QuickCheck >= 2.4.1.1,
                 test-framework,

--- a/tests/suite.hs
+++ b/tests/suite.hs
@@ -1,67 +1,68 @@
-import Test.Framework (defaultMain, testGroup, Test)
-import Test.Framework.Providers.HUnit
-import Test.Framework.Providers.QuickCheck2
-import Test.QuickCheck
-import Test.HUnit hiding (Test)
+import           Test.Framework                       (Test, defaultMain,
+                                                       testGroup)
+import           Test.Framework.Providers.HUnit
+import           Test.Framework.Providers.QuickCheck2
+import           Test.HUnit                           hiding (Test)
+import           Test.QuickCheck
 
-import Data.Binary
-import qualified Data.OpenPGP as OpenPGP
-import qualified Data.OpenPGP.Crypto as OpenPGP
-import qualified Data.ByteString.Lazy as LZ
-import qualified Data.ByteString.Lazy.UTF8 as LZ (fromString)
+import           Data.Binary
+import qualified Data.ByteString.Lazy                 as LZ
+import qualified Data.ByteString.Lazy.UTF8            as LZ (fromString)
+import qualified Data.OpenPGP                         as OpenPGP
+import qualified Data.OpenPGP.Crypto                  as OpenPGP
 
 instance Arbitrary OpenPGP.HashAlgorithm where
-	arbitrary = elements [OpenPGP.MD5, OpenPGP.SHA1, OpenPGP.SHA256, OpenPGP.SHA384, OpenPGP.SHA512]
+        arbitrary = elements [OpenPGP.MD5, OpenPGP.SHA1, OpenPGP.SHA256, OpenPGP.SHA384, OpenPGP.SHA512]
 
 testFingerprint :: FilePath -> String -> Assertion
 testFingerprint fp kf = do
-	bs <- LZ.readFile $ "tests/data/" ++ fp
-	let (OpenPGP.Message [packet]) = decode bs
-	assertEqual ("for " ++ fp) kf (OpenPGP.fingerprint packet)
+        bs <- LZ.readFile $ "tests/data/" ++ fp
+        let (OpenPGP.Message [packet]) = decode bs
+        assertEqual ("for " ++ fp) kf (OpenPGP.fingerprint packet)
 
 testVerifyMessage :: FilePath -> FilePath -> Assertion
 testVerifyMessage keyring message = do
-	keys <- fmap decode $ LZ.readFile $ "tests/data/" ++ keyring
-	m <- fmap decode $ LZ.readFile $ "tests/data/" ++ message
-	let verification = OpenPGP.verify keys m 0
-	assertEqual (keyring ++ " for " ++ message) True verification
+        keys <- fmap decode $ LZ.readFile $ "tests/data/" ++ keyring
+        m <- fmap decode $ LZ.readFile $ "tests/data/" ++ message
+        let verification = OpenPGP.verify keys m 0
+        assertEqual (keyring ++ " for " ++ message) True verification
 
 prop_sign_and_verify :: OpenPGP.Message -> String -> OpenPGP.HashAlgorithm -> String -> String -> Bool
 prop_sign_and_verify secring kid halgo filename msg =
-	let
-		m = OpenPGP.LiteralDataPacket {
-			OpenPGP.format = 'u',
-			OpenPGP.filename = filename,
-			OpenPGP.timestamp = 12341234,
-			OpenPGP.content = LZ.fromString msg
-		}
-		sig = OpenPGP.sign secring (OpenPGP.Message [m]) halgo kid 12341234
-	in
-		OpenPGP.verify secring (OpenPGP.Message [m,sig]) 0
+        let
+                m = OpenPGP.LiteralDataPacket {
+                        OpenPGP.format = 'u',
+                        OpenPGP.filename = filename,
+                        OpenPGP.timestamp = 12341234,
+                        OpenPGP.content = LZ.fromString msg
+                }
+                sig = OpenPGP.sign secring (OpenPGP.Message [m]) halgo kid 12341234
+        in
+                OpenPGP.verify secring (OpenPGP.Message [m,sig]) 0
 
 tests :: OpenPGP.Message -> [Test]
 tests secring =
-	[
-		testGroup "Fingerprint" [
-			testCase "000001-006.public_key" (testFingerprint "000001-006.public_key" "421F28FEAAD222F856C8FFD5D4D54EA16F87040E"),
-			testCase "000016-006.public_key" (testFingerprint "000016-006.public_key" "AF95E4D7BAC521EE9740BED75E9F1523413262DC"),
-			testCase "000027-006.public_key" (testFingerprint "000027-006.public_key" "1EB20B2F5A5CC3BEAFD6E5CB7732CF988A63EA86"),
-			testCase "000035-006.public_key" (testFingerprint "000035-006.public_key" "CB7933459F59C70DF1C3FBEEDEDC3ECF689AF56D")
-		],
-		testGroup "Message verification" [
-			--testCase "uncompressed-ops-dsa" (testVerifyMessage "pubring.gpg" "uncompressed-ops-dsa.gpg"),
-			--testCase "uncompressed-ops-dsa-sha384" (testVerifyMessage "pubring.gpg" "uncompressed-ops-dsa-sha384.txt.gpg"),
-			testCase "uncompressed-ops-rsa" (testVerifyMessage "pubring.gpg" "uncompressed-ops-rsa.gpg"),
-			testCase "compressedsig" (testVerifyMessage "pubring.gpg" "compressedsig.gpg"),
-			testCase "compressedsig-zlib" (testVerifyMessage "pubring.gpg" "compressedsig-zlib.gpg"),
-			testCase "compressedsig-bzip2" (testVerifyMessage "pubring.gpg" "compressedsig-bzip2.gpg")
-		],
-		testGroup "Signing" [
-			testProperty "Crypto signatures verify" (prop_sign_and_verify secring "FEF8AFA0F661C3EE")
-		]
-	]
+        [
+                testGroup "Fingerprint" [
+                        testCase "000001-006.public_key" (testFingerprint "000001-006.public_key" "421F28FEAAD222F856C8FFD5D4D54EA16F87040E"),
+                        testCase "000016-006.public_key" (testFingerprint "000016-006.public_key" "AF95E4D7BAC521EE9740BED75E9F1523413262DC"),
+                        testCase "000027-006.public_key" (testFingerprint "000027-006.public_key" "1EB20B2F5A5CC3BEAFD6E5CB7732CF988A63EA86"),
+                        testCase "000035-006.public_key" (testFingerprint "000035-006.public_key" "CB7933459F59C70DF1C3FBEEDEDC3ECF689AF56D")
+                ],
+                testGroup "Message verification" [
+                        --testCase "uncompressed-ops-dsa" (testVerifyMessage "pubring.gpg" "uncompressed-ops-dsa.gpg"),
+                        --testCase "uncompressed-ops-dsa-sha384" (testVerifyMessage "pubring.gpg" "uncompressed-ops-dsa-sha384.txt.gpg"),
+                        testCase "uncompressed-ops-rsa" (testVerifyMessage "pubring.gpg" "uncompressed-ops-rsa.gpg"),
+                        testCase "compressedsig" (testVerifyMessage "pubring.gpg" "compressedsig.gpg"),
+                        testCase "compressedsig-zlib" (testVerifyMessage "pubring.gpg" "compressedsig-zlib.gpg"),
+                        testCase "compressedsig-bzip2" (testVerifyMessage "pubring.gpg" "compressedsig-bzip2.gpg")
+                ],
+                testGroup "Signing" [
+                        testProperty "Crypto signatures verify" (prop_sign_and_verify secring "FEF8AFA0F661C3EE")
+                ]
+        ]
 
 main :: IO ()
 main = do
-	secring <- fmap decode $ LZ.readFile "tests/data/secring.gpg"
-	defaultMain (tests secring)
+        secring <- fmap decode $ LZ.readFile "tests/data/secring.gpg"
+        defaultMain (tests secring)


### PR DESCRIPTION
As explained in the compat-shim commit, this isn't a proper adaptation to the openpgp-0.6 API, but merely the path of least resistance to restore compatibility. I'm submitting this as PR as I'm using this locally succesfully, and in the hopes this may be useful to other people.